### PR TITLE
Feature/refacter table of c ontents py scripts

### DIFF
--- a/Crawling_Web_site/Web_Novels/README.md
+++ b/Crawling_Web_site/Web_Novels/README.md
@@ -1,0 +1,195 @@
+# Web Novels Scraper (なろう / カクヨム 一括取得ツール)
+
+小説家になろう（ncode.syosetu.com）および カクヨム（kakuyomu.jp）から小説の目次情報をスクレイピングし、ローカルにHTMLとJSON形式で保存するツール群です。
+SQLiteデータベース、またはCSV形式のリストファイルを用いて、**「更新があった作品のみを差分取得する」**スマートな一括処理（バッチ処理）に対応しています。
+
+## 🌟 特徴
+- **差分更新対応:** SQLite DBまたはCSVの最終更新日時を比較し、無駄な通信とファイル出力をスキップ。
+- **統合バッチ処理:** なろう・カクヨム両方のサイトを1つのコマンドで一括更新。
+- **モード切替:** コマンドライン引数 `--mode sqlite` / `--mode csv` で管理形式を柔軟に変更可能。
+
+---
+
+## 🛠 前提条件 (Prerequisites)
+
+このスクリプトをまっさらな環境で実行するためには、以下のツールが必要です。
+
+- **OS:** macOS / Linux / Windows (macOS推奨)
+- **Python:** 3.13 以上
+- **パッケージマネージャ:** Pipenv
+
+### Mac環境での推奨セットアップ（Homebrewを使用）
+まだPython環境がない場合は、`pyenv` と `pipenv` をインストールしてください。
+```bash
+brew install pyenv pipenv openssl xz
+```
+
+---
+
+## 🚀 環境構築手順 (Installation)
+
+### 1. リポジトリの取得
+Gitからメインブランチのソースコードをクローンし、対象ディレクトリへ移動します。
+```bash
+git clone [https://github.com/Mokaku/Home_Tools.git](https://github.com/Mokaku/Home_Tools.git)
+cd Home_Tools/Crawling_Web_site/Web_Novels
+```
+
+### 2. Pythonのインストールと仮想環境の構築
+本プロジェクトは `Pipenv` を使用して依存パッケージ（BeautifulSoup4, requests 等）を管理しています。スクリプトのあるディレクトリ（`Pipfile` がある場所）に移動してセットアップを行います。
+
+```bash
+# スクリプトとPipfileがあるディレクトリへ移動
+cd src/python
+
+# 依存パッケージのインストール（仮想環境の自動作成）
+pipenv install
+```
+
+> **⚠️ 【重要】MacでPythonのインストールエラー（SSLモジュールエラー）が出る場合**
+> Mac環境で `pipenv install` 時にSSLエラーが出たり、pyenvでのPythonビルドが失敗する場合は、Mac標準のコンパイラとHomebrewのOpenSSLを明示的に指定してPythonをインストールしてください。
+> ```bash
+> # 1. Command Line Toolsの再インストール（必要な場合のみ）
+> sudo rm -rf /Library/Developer/CommandLineTools
+> xcode-select --install
+> 
+> # 2. Apple純正ツールを強制指定してPython 3.13系をインストール
+> AR=/usr/bin/ar RANLIB=/usr/bin/ranlib CC=clang LDFLAGS="-L$(brew --prefix openssl@3)/lib" CPPFLAGS="-I$(brew --prefix openssl@3)/include" pyenv install 3.13.2
+> 
+> # 3. インストールしたバージョンをローカルに適用し、再度Pipenvを実行
+> pyenv local 3.13.2
+> pipenv install
+> ```
+
+---
+
+## 📁 ディレクトリ構成
+
+実行前に、以下のディレクトリ構成になっていることを確認してください（スクリプト実行時に自動生成されるものもあります）。
+
+```text
+Web_Novels/
+├── html/                  # 生成されたHTML/JSONが出力される場所
+├── novel_database/        # DBおよびCSVリストの保存場所
+│   ├── kakuyomu_all_novel_id.list
+│   ├── narou_all_novel_id.list
+│   └── sampl_database_01.db (自動生成)
+└── src/
+    └── python/            # スクリプト本体
+        ├── Pipfile
+        ├── get_all_work_list.py             # 統合バッチスクリプト
+        ├── get_narou_TableOfContents.py     # なろう個別スクリプト
+        └── get_kakuyomu_TableOfContents.py  # カクヨム個別スクリプト
+```
+
+---
+
+## 使い方 (Usage)
+
+スクリプトはすべて `src/python/` ディレクトリ内で、`pipenv run` を付けて実行します。
+
+### 1. 統合バッチによる一括取得（推奨）
+DB（またはCSV）に登録されている `flag = 1` の全作品を巡回し、更新があったものだけを取得します。
+
+**SQLiteモードで実行（デフォルト）:**
+```bash
+pipenv run python get_all_work_list.py
+```
+**CSVモードで実行:**
+```bash
+pipenv run python get_all_work_list.py --mode csv
+```
+
+### 2. 個別作品の手動取得
+特定の作品だけをピンポイントで取得・更新したい場合は、個別スクリプトにIDを渡して実行します。
+（※初回実行時、自動的にDBまたはCSVに作品情報が登録されます）
+
+**なろうの作品を取得:**
+```bash
+pipenv run python get_narou_TableOfContents.py n2732lu
+```
+**カクヨムの作品を取得:**
+```bash
+pipenv run python get_kakuyomu_TableOfContents.py 16817330667341551839
+```
+
+---
+
+## 📝 データベース/リストの仕様
+
+### SQLiteデータベース (`sampl_database_01.db`)
+初回実行時に自動作成される `novels` テーブルで管理されます。
+- `novel_id` (TEXT): nコード、またはカクヨムの19桁ID
+- `site_type` (TEXT): `narou` または `kakuyomu`
+- `flag` (INTEGER): `1`=一括処理の対象 / `0`=対象外
+- `title` (TEXT): 作品名
+- `last_update` (TEXT): 最終更新日時
+
+### CSVリスト (`.list` ファイル)
+カンマ区切りで管理されます。手動で追記する場合は以下のフォーマットに従ってください。
+`[ID], [取得フラグ(1 or 0)], [タイトル]`
+
+*(例: narou_all_novel_id.list)*
+```csv
+n2732lu, 1, リナニア戦記　～悪役貴族と転生従士は平和の国の夢を見るか～
+n6453iq, 0, 春暁記
+```
+
+---
+
+## 🗄️ SQLite 基本操作チートシート
+
+運用中、直接データベースの中身を確認したり、手動でフラグを修正したりするための基本的なコマンドリストです。
+
+### 1. データベースへの接続と終了
+ターミナルで以下のコマンドを入力してSQLiteを起動します。
+```bash
+# データベースファイルを開く (※パスは実行場所に合わせる)
+sqlite3 ../../novel_database/sampl_database_01.db
+```
+
+SQLiteのプロンプト (`sqlite>`) に入ったら、以下のコマンドが使えます。
+```sql
+.tables           -- 存在するテーブルの一覧を表示 (novels と出ればOK)
+.schema novels    -- テーブルの構造(カラム名や型)を確認
+.mode column      -- ★おすすめ: 検索結果を縦に揃えて見やすくする
+.headers on       -- ★おすすめ: 検索結果の一番上にカラム名を表示する
+.quit             -- SQLiteを終了して元のターミナルに戻る
+```
+
+### 2. データの確認 (SELECT)
+※SQL文の最後には必ず `;` (セミコロン) をつけてエンターを押します。
+
+**登録されている全データを表示**
+```sql
+SELECT * FROM novels;
+```
+
+**「なろう」の作品だけを絞り込んで表示**
+```sql
+SELECT novel_id, title, last_update FROM novels WHERE site_type = 'narou';
+```
+
+**「バッチ処理の対象 (flag=1)」の作品だけを表示**
+```sql
+SELECT novel_id, site_type, title FROM novels WHERE flag = 1;
+```
+
+### 3. データの更新・変更 (UPDATE)
+作品を一括取得の対象外にしたい場合などに使用します。
+
+**特定の作品を一括取得の「対象外 (flag=0)」に変更する**
+```sql
+UPDATE novels SET flag = 0 WHERE novel_id = 'n2732lu';
+```
+*(※元に戻すときは `SET flag = 1` にして実行します)*
+
+### 4. データの削除 (DELETE)
+不要になった作品をデータベースから完全に消去します。
+*(※削除は取り消せないので実行前にIDをよく確認してください)*
+
+**特定の作品を削除する**
+```sql
+DELETE FROM novels WHERE novel_id = 'n6453iq';
+```
+

--- a/Crawling_Web_site/Web_Novels/src/python/get_all_work_list.py
+++ b/Crawling_Web_site/Web_Novels/src/python/get_all_work_list.py
@@ -1,0 +1,118 @@
+import os
+import sys
+import subprocess
+import sqlite3
+import argparse
+
+# ==========================================
+# === 設定 ===
+# ==========================================
+LIST_DIR = "../../novel_database/"
+DB_FILE_PATH = os.path.join(LIST_DIR, "sampl_database_01.db")
+
+# CSVモード時に読み込むリストの定義
+CSV_TARGETS = {
+    "narou": os.path.join(LIST_DIR, "narou_all_novel_id.list"),
+    "kakuyomu": os.path.join(LIST_DIR, "kakuyomu_all_novel_id.list")
+}
+
+# 呼び出すスクリプトの定義
+SCRIPTS = {
+    "narou": "get_narou_TableOfContents.py",
+    "kakuyomu": "get_kakuyomu_TableOfContents.py"
+}
+# ==========================================
+
+
+def get_targets_from_sqlite():
+    """SQLiteから実行対象(flag=1)の全サイトのリストを取得する"""
+    if not os.path.exists(DB_FILE_PATH):
+        print(f"エラー: データベースファイルが見つかりません ({DB_FILE_PATH})")
+        return []
+
+    conn = sqlite3.connect(DB_FILE_PATH)
+    cursor = conn.cursor()
+    
+    try:
+        # サイトに関わらず、flagが1のものを全て取得
+        cursor.execute('SELECT novel_id, site_type, title FROM novels WHERE flag = 1')
+        rows = cursor.fetchall()
+        return rows
+    except sqlite3.OperationalError:
+        print("エラー: テーブルが存在しません。")
+        return []
+    finally:
+        conn.close()
+
+
+def get_targets_from_csv():
+    """なろうとカクヨムの両方のCSVから実行対象(flag=1)のリストを取得する"""
+    targets = []
+    
+    for site_type, csv_path in CSV_TARGETS.items():
+        if not os.path.exists(csv_path):
+            print(f"警告: リストファイルが見つかりません ({csv_path})")
+            continue
+
+        with open(csv_path, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                
+                parts = line.split(',', 2)
+                if len(parts) >= 3:
+                    novel_id = parts[0].strip()
+                    flag = parts[1].strip()
+                    title = parts[2].strip()
+                    
+                    if flag == "1":
+                        # SQLiteの戻り値と合わせる: (novel_id, site_type, title)
+                        targets.append((novel_id, site_type, title))
+                    else:
+                        print(f"PASS: [{site_type}] {title}")
+                        
+    return targets
+
+
+def main():
+    # バッチ自体のコマンドライン引数を設定
+    parser = argparse.ArgumentParser(description="統合一括スクレイピングバッチ")
+    parser.add_argument("--mode", choices=["sqlite", "csv"], default="sqlite", 
+                        help="一括処理の管理形式 (デフォルト: sqlite)")
+    args = parser.parse_args()
+    
+    run_mode = args.mode
+
+    print(f"=== 統合一括取得バッチ開始 (モード: {run_mode}) ===")
+
+    # 1. ターゲットの取得
+    if run_mode == "sqlite":
+        targets = get_targets_from_sqlite()
+    else:
+        targets = get_targets_from_csv()
+
+    if not targets:
+        print("実行対象のコンテンツがありませんでした。")
+        sys.exit(0)
+
+    # 2. ターゲットの実行ループ
+    for novel_id, site_type, title in targets:
+        print(f"\n==========================================")
+        print(f"処理開始: [{site_type}] {title} (ID: {novel_id})")
+        print(f"==========================================")
+        
+        target_script = SCRIPTS.get(site_type)
+        if not target_script or not os.path.exists(target_script):
+            print(f"エラー: 対応するスクリプトが見つからないか未定義です ({site_type})")
+            continue
+        
+        # 個別スクリプトに novel_id と --mode 引数を渡して実行
+        subprocess.run([sys.executable, target_script, novel_id, "--mode", run_mode])
+
+    print("\n=== 統合一括取得バッチ完了 ===")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/Crawling_Web_site/Web_Novels/src/python/get_kakuyomu_TableOfContents.py
+++ b/Crawling_Web_site/Web_Novels/src/python/get_kakuyomu_TableOfContents.py
@@ -3,25 +3,54 @@ import json
 import os
 import sys
 import re  # 追加: 日付の正規表現チェック用
+import sqlite3
+import argparse
 
 from bs4 import BeautifulSoup
-
 import requests
 
-args = sys.argv
+# ==========================================
+# === 引数と管理形式の設定 ===
+# ==========================================
+# コマンドライン引数の設定
+parser = argparse.ArgumentParser(description="カクヨム!の目次を取得・更新します")
+parser.add_argument("novel_id", type=str, help="取得する小説のID（例: 16817330667341551839）")
+parser.add_argument("--mode", type=str, choices=["sqlite", "csv"], default="sqlite", 
+                    help="管理形式の指定 (デフォルト: sqlite)")
+args = parser.parse_args()
+
+## args = sys.argv
 
 # print(args[1])
 # print(len(args))
 
-if 2 <= len(args):
-    if args[1].isdigit():
-        novel_id = args[1]
-    else:
-        print('Argument is not digit')
-        sys.exit(1)  # 修正: エラー時は後続処理を止め、安全に終了させる
-else:
-    print('Arguments are too short')
-    sys.exit(1)  # 修正: エラー時は後続処理を止め、安全に終了させる
+## if 2 <= len(args):
+##     if args[1].isdigit():
+##         novel_id = args[1]
+##     else:
+##         print('Argument is not digit')
+##         sys.exit(1)  # 修正: エラー時は後続処理を止め、安全に終了させる
+## else:
+##     print('Arguments are too short')
+##     sys.exit(1)  # 修正: エラー時は後続処理を止め、安全に終了させる
+
+# ==========================================
+# === 管理形式の設定（ここでモードを切り替えます）===
+# ==========================================
+# 引数から値を取得
+novel_id = args.novel_id
+MANAGEMENT_MODE = "sqlite"  # "csv" または "sqlite" を指定
+SITE_TYPE = "kakuyomu"         # DB用のサイト識別子
+
+# ファイルパスの定義
+LIST_DIR = "../../novel_database/"
+CSV_FILE_NAME = "narou_all_novel_id.list"
+DB_FILE_NAME = "sampl_database_01.db"
+
+CSV_FILE_PATH = os.path.join(LIST_DIR, CSV_FILE_NAME)
+DB_FILE_PATH = os.path.join(LIST_DIR, DB_FILE_NAME)
+# ==========================================
+
 
 kakuyomu_url = "https://kakuyomu.jp"
 kakuyomu_user_page_url = "https://kakuyomu.jp/users"
@@ -195,56 +224,63 @@ def get_chapter_title(f):
                 print("</ul>", file=f)
             #     print (chapter_id, chapter_title)
 
+# ==========================================
+# データベース / CSV 管理用関数群
+# ==========================================
 
-def main():
-
-    novel_info = GetBaseNobelInfo(work_id, rec01)
-
-    ## # --- デバッグ用: 現在のJSON構造をファイルに書き出して確認する ---
-    ## with open("debug_apollo_state.json", "w", encoding="utf-8") as f_debug:
-    ##     json.dump(rec01, f_debug, indent=4, ensure_ascii=False)
-    ## print("デバッグ用のJSONを debug_apollo_state.json に出力しました。新しいキー構成を確認してください。")
-    ## # -------------------------------------------------------------
-
-    auther_url = f"{kakuyomu_user_page_url}/{novel_info.only_get_auther_name()}"
-    # auther_url = tmp_url.strip(" ")
-
-    ###################################################
-    # 出力用　HTML HEADER
-
-    # 修正: f-string に統一
-    html_head = f"""
-    <!DOCTYPE html>
-    <html lang=ja>
-    <html><head><title>{novel_info.only_get_work_title()}(id:{work_id})</title></head>
-    <body>
-    <h1>目次</h1>
-    """.strip()
-
-    ###################################################
-    # 出力用　HTML FOOTER
-
-    html_footer = """
-    </body>
-    </html>
+def manage_with_sqlite(db_path, novel_id, site_type, title, latest_date):
     """
-    ###################################################
+    SQLiteを用いて更新日時を管理し、更新の有無を返す関数
+    """
+    is_updated = True
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
 
-    info_text = '## For Novel DB:\n{}, 1, {}'
-    bookmark_html = '## For Bookmark File:\n<li><a href="file://{2}/Documents/Test/Novels/html/kakuyomu_{0}.html">{1} (id:{0})</a>({3})'
-    print(info_text.format(work_id, novel_info.only_get_work_title()))
-    print(bookmark_html.format(work_id, novel_info.only_get_work_title(), home_dir, novel_info.only_get_auther_activity_name()))
+    # DBに接続（ファイルがない場合は自動作成されます）
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
 
-    # ---------------------------------------------------------
-    # 追加: 更新判定と kakuyomu_all_novel_id.list の更新処理
-    # ---------------------------------------------------------
-    latest_date = novel_info.only_get_work_last_update()
+    # テーブル作成（初回のみ実行される）
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS novels (
+            novel_id TEXT PRIMARY KEY,
+            site_type TEXT,
+            flag INTEGER,
+            title TEXT,
+            last_update TEXT
+        )
+    ''')
 
-    list_dir = "../../novel_database/"
-    list_file = "kakuyomu_all_novel_id.list"  # 必要に応じて変更してください
-    list_path = os.path.join(list_dir, list_file)
-    
-    is_updated = True # 初期値は更新あり
+    # 現在登録されているデータを検索
+    cursor.execute('SELECT last_update, flag FROM novels WHERE novel_id = ?', (novel_id,))
+    row = cursor.fetchone()
+
+    if row:
+        db_last_update = row[0]
+        # 更新日が同じならスキップ判定
+        if latest_date and db_last_update == latest_date:
+            is_updated = False
+        else:
+            # 日付が変わっていればレコードを更新
+            cursor.execute('UPDATE novels SET title = ?, last_update = ? WHERE novel_id = ?', 
+                           (title, latest_date, novel_id))
+    else:
+        # 新規登録（CSVに合わせたデフォルトフラグとして 1 を設定）
+        cursor.execute('INSERT INTO novels (novel_id, site_type, flag, title, last_update) VALUES (?, ?, ?, ?, ?)',
+                       (novel_id, site_type, 1, title, latest_date))
+
+    # 変更を保存して接続を閉じる
+    conn.commit()
+    conn.close()
+
+    return is_updated
+
+
+def manage_with_csv(list_path, novel_id, latest_date):
+    """
+    CSV(.list)形式を用いて更新日時を管理し、更新の有無を返す関数
+    （これまでの処理をそのまま関数化したものです）
+    """
+    is_updated = True
 
     if os.path.exists(list_path):
         with open(list_path, "r", encoding="utf-8") as f:
@@ -252,18 +288,15 @@ def main():
             
         new_lines = []
         for line in lines:
-            if line.startswith(f"{work_id},"):
-                # "id, flag, title[, date]" という構成を前提にパース
+            if line.startswith(f"{novel_id},"):
                 parts = line.split(',', 2)
                 if len(parts) == 3:
-                    # すでに同じ最新日時が記録されている場合は更新スキップ
                     if latest_date and (latest_date in parts[2]):
                         is_updated = False
                         new_lines.append(line)
                     else:
-                        # 既存の日付を正規表現で探して置換するか、追記する
-                        # カクヨムの日付フォーマット (YYYY年MM月DD日) を想定
                         sub_parts = parts[2].rsplit(',', 1)
+                        # カクヨムの日付フォーマットに合わせた正規表現
                         if len(sub_parts) == 2 and re.search(r'\d{4}年\d{2}月\d{2}日', sub_parts[1]):
                             new_line = f"{parts[0]},{parts[1]},{sub_parts[0]}, {latest_date}\n"
                         else:
@@ -275,57 +308,93 @@ def main():
             else:
                 new_lines.append(line)
                 
-        # 更新が確認された場合のみ、リストファイルを上書き更新
         if is_updated:
-            os.makedirs(list_dir, exist_ok=True)
+            os.makedirs(os.path.dirname(list_path), exist_ok=True)
             with open(list_path, "w", encoding="utf-8") as f:
                 f.writelines(new_lines)
     else:
         print(f"警告: リストファイルが見つかりません ({list_path})")
 
-    # 3. 更新有無に応じたHTMLの出力処理
+    return is_updated
+
+# ==========================================
+
+
+def main():
+
+    # 1. 取得したデータから作品情報と最新の更新日時を抽出
+    novel_info = GetBaseNobelInfo(work_id, rec01)
+
+    print("--------------------------------")
+    novel_title = novel_info.only_get_work_title()
+    novel_auther = novel_info.only_get_auther_activity_name()
+    latest_date = novel_info.only_get_work_last_update()
+    
+    print("タイトル:", novel_title)
+    print("作者:", novel_auther)
+    print("#################")
+
+    # 2. 設定されたモードに応じて、DBまたはCSVの更新関数を呼び出す
+    if MANAGEMENT_MODE == "sqlite":
+        print(f"[SQLiteモードで実行中] DB: {DB_FILE_NAME}")
+        is_updated = manage_with_sqlite(DB_FILE_PATH, work_id, SITE_TYPE, novel_title, latest_date)
+    elif MANAGEMENT_MODE == "csv":
+        print(f"[CSVモードで実行中] List: {CSV_FILE_NAME}")
+        is_updated = manage_with_csv(CSV_FILE_PATH, work_id, latest_date)
+    else:
+        print("エラー: MANAGEMENT_MODE の設定が不正です。")
+        sys.exit(1)
+
+
+    # 3. 更新有無に応じたHTMLの出力
     if is_updated:
         print(f"【更新あり】コンテンツに更新が検出されました (最終更新: {latest_date})。HTMLを出力します。")
-        with open(filename, 'w', encoding='utf-8') as f:
-            print(html_head, file=f)
-            # get_work_info()
-            # get_auther_info(auther_id)
 
-            # 修正: f-stringによる文字列結合。HTMLタグの構造が分かりやすくなります。
-            print(f"<h2> {novel_info.only_get_work_title()} (id:{work_id}) </h2>", file=f)
-            print(f"<h2> by <a href=\"{auther_url}\">{novel_info.only_get_auther_activity_name()}</a>", file=f)
+        # HTML出力用の変数準備
+        auther_url = f"{kakuyomu_user_page_url}/{novel_info.only_get_auther_name()}"
+        html_head = f"""
+        <!DOCTYPE html>
+        <html lang=ja>
+        <html><head><title>{novel_title}(id:{work_id})</title></head>
+        <body>
+        <h1>目次</h1>
+        """.strip()
+
+        html_footer = """
+        </body>
+        </html>
+        """
+
+        # ブックマーク・DB用情報の出力（既存の動作を維持）
+        info_text = '## For Novel DB:\n{}, 1, {}'
+        bookmark_html = '## For Bookmark File:\n<li><a href="file://{2}/Documents/Test/Novels/html/kakuyomu_{0}.html">{1} (id:{0})</a>({3})'
+        print(info_text.format(work_id, novel_title))
+        print(bookmark_html.format(work_id, novel_title, home_dir, novel_auther))
+
+        # 出力先ディレクトリが存在しなければ自動作成する
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+
+        with open(filename, 'w', encoding='utf-8') as f:
+
+            print(html_head, file=f)
+            print(f"<h2> {novel_title} (id:{work_id}) </h2>", file=f)
+            print(f"<h2> by <a href=\"{auther_url}\">{novel_auther}</a>", file=f)
             print(f" ( 最終更新日：{latest_date} ) </h2>", file=f)
 
-            # test チャプター有り無し判定により出力内容を変更する
-            # 「Chapter:」から始まるキー（実際のチャプター情報）が存在するかで判定する
+            # チャプター有り無し判定により出力内容を変更する
             has_chapter = any(k.startswith("Chapter:") for k in rec01)
 
             if has_chapter:
-                # print("チャプターあり")
                 get_chapter_title(f)
             else:
-                # print("チャプターなし")
                 get_episode_info(f)
 
-            # test チャプター有り無し判定により出力内容を変更する
-            ## 過去の実装方法を残しておく
-            ## if (len(j["props"]["pageProps"]["__APOLLO_STATE__"]["Work:" + work_id]["tableOfContents"]) > 1):
-            ##     # print("チャープターあり")
-            ##     get_chapter_title(f)
-            ## else:
-            ##     # print("チャープターなし")
-            ##     get_episode_info(f)
-
-            # get_chapter_info()
             print(html_footer, file=f)
 
-            # f.close()  <-- 修正: with文のスコープを抜けると自動でクローズされるため削除（コメントとして残しています）
-
-            # with open(filename) as f:
-            #     contents = f.read()
-            #     print(contents)  # hello
     else:
         print(f"【更新なし】コンテンツに変更はありませんでした (最終更新: {latest_date})。HTMLの出力処理をスキップします。")
 
 
 main()
+
+

--- a/Crawling_Web_site/Web_Novels/src/python/get_narou_TableOfContents.py
+++ b/Crawling_Web_site/Web_Novels/src/python/get_narou_TableOfContents.py
@@ -121,7 +121,7 @@ def get_all_pages(page_num, novel_series_name, novel_title, novel_auther):
     ep_num = 1
     chp_num = 1
     page_num = int(page_num) + 1
-    contents_json = {"__typename": "Story", "id": novel_id, "serieis": novel_series_name, "title": novel_title, "AutherName": novel_auther}
+    contents_json = {"__typename": "Story", "id": novel_id, "series": novel_series_name, "title": novel_title, "AuthorName": novel_auther}
 
     # Chapterの無いNovelのためにます、 ep_list とchapter_jsonを初期化しておく。
     chapter_json_name = "Chapters_1"
@@ -388,6 +388,9 @@ def main():
     # 3. 更新有無に応じたHTML/JSONの出力
     if is_updated:
         print(f"【更新あり】コンテンツに更新が検出されました (最終更新: {latest_date})。HTMLとJSONを出力します。")
+
+        os.makedirs(os.path.dirname(json_filename), exist_ok=True)
+        os.makedirs(os.path.dirname(html_filename), exist_ok=True)
         
         with open(json_filename, 'w', encoding='utf-8') as f:
             print(json.dumps(list_dict, indent=4, ensure_ascii=False), file=f)

--- a/Crawling_Web_site/Web_Novels/src/python/get_narou_TableOfContents.py
+++ b/Crawling_Web_site/Web_Novels/src/python/get_narou_TableOfContents.py
@@ -3,29 +3,40 @@ import json
 import sys
 import os
 import re
+import sqlite3
+import argparse
 
 from bs4 import BeautifulSoup
-
 import requests
 
-args = sys.argv
+# ==========================================
+# === 引数と管理形式の設定 ===
+# ==========================================
+# コマンドライン引数の設定
+parser = argparse.ArgumentParser(description="なろう小説の目次を取得・更新します")
+parser.add_argument("novel_id", type=str, help="取得する小説のID（例: n2732lu）")
+parser.add_argument("--mode", type=str, choices=["sqlite", "csv"], default="sqlite", 
+                    help="管理形式の指定 (デフォルト: sqlite)")
+args = parser.parse_args()
 
+
+
+## args = sys.argv
 # print(args[1])
 # print(len(args))
 
-if 2 <= len(args):
-    novel_id = args[1]
-    # if args[1].isdigit():
-    #     novel_id = args[1]
-    # else:
-    #     print('Argument is not digit')
-else:
-    print('Arguments are too short')
-    sys.exit(1) # 修正: 引数不足時は後続処理を止め、安全に終了させる
+## if 2 <= len(args):
+##     novel_id = args[1]
+## else:
+##     print('Arguments are too short')
+##     sys.exit(1) # 修正: 引数不足時は後続処理を止め、安全に終了させる
 
 # ==========================================
 # === 管理形式の設定（ここでモードを切り替えます）===
 # ==========================================
+# 引数から値を取得
+novel_id = args.novel_id
+
 MANAGEMENT_MODE = "sqlite"  # "csv" または "sqlite" を指定
 SITE_TYPE = "narou"         # DB用のサイト識別子
 
@@ -209,7 +220,7 @@ def create_html_file(list_dict, f_html):
 
     # 修正: f-stringの適用
     print(f"<h2> {list_dict['title']} (id: {list_dict['id']}) </h2>", file=f_html)
-    print(f"<h2> by <a href=\"{load_url}\">{list_dict['AutherName']}</a> </h2>", file=f_html)
+    print(f"<h2> by <a href=\"{load_url}\">{list_dict['AuthorName']}</a> </h2>", file=f_html)
 
     for chap_list_key in list_dict:
         if "Chapters_" in chap_list_key:

--- a/Crawling_Web_site/Web_Novels/src/python/get_narou_TableOfContents.py
+++ b/Crawling_Web_site/Web_Novels/src/python/get_narou_TableOfContents.py
@@ -23,6 +23,21 @@ else:
     print('Arguments are too short')
     sys.exit(1) # 修正: 引数不足時は後続処理を止め、安全に終了させる
 
+# ==========================================
+# === 管理形式の設定（ここでモードを切り替えます）===
+# ==========================================
+MANAGEMENT_MODE = "sqlite"  # "csv" または "sqlite" を指定
+SITE_TYPE = "narou"         # DB用のサイト識別子
+
+# ファイルパスの定義
+LIST_DIR = "../../novel_database/"
+CSV_FILE_NAME = "narou_all_novel_id.list"
+DB_FILE_NAME = "sampl_database_01.db"
+
+CSV_FILE_PATH = os.path.join(LIST_DIR, CSV_FILE_NAME)
+DB_FILE_PATH = os.path.join(LIST_DIR, DB_FILE_NAME)
+# ==========================================
+
 source_dir = "../../json_source"
 source_file = "daysneo_da59da23660b4fa346e5717aed10e147.html"
 
@@ -214,9 +229,104 @@ def create_html_file(list_dict, f_html):
     print(html_footer, file=f_html)
 
 
+# ==========================================
+# データベース / CSV 管理用関数群
+# ==========================================
+
+def manage_with_sqlite(db_path, novel_id, site_type, title, latest_date):
+    """
+    SQLiteを用いて更新日時を管理し、更新の有無を返す関数
+    """
+    is_updated = True
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+
+    # DBに接続（ファイルがない場合は自動作成されます）
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    # テーブル作成（初回のみ実行される）
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS novels (
+            novel_id TEXT PRIMARY KEY,
+            site_type TEXT,
+            flag INTEGER,
+            title TEXT,
+            last_update TEXT
+        )
+    ''')
+
+    # 現在登録されているデータを検索
+    cursor.execute('SELECT last_update, flag FROM novels WHERE novel_id = ?', (novel_id,))
+    row = cursor.fetchone()
+
+    if row:
+        db_last_update = row[0]
+        # 更新日が同じならスキップ判定
+        if latest_date and db_last_update == latest_date:
+            is_updated = False
+        else:
+            # 日付が変わっていればレコードを更新
+            cursor.execute('UPDATE novels SET title = ?, last_update = ? WHERE novel_id = ?', 
+                           (title, latest_date, novel_id))
+    else:
+        # 新規登録（CSVに合わせたデフォルトフラグとして 1 を設定）
+        cursor.execute('INSERT INTO novels (novel_id, site_type, flag, title, last_update) VALUES (?, ?, ?, ?, ?)',
+                       (novel_id, site_type, 1, title, latest_date))
+
+    # 変更を保存して接続を閉じる
+    conn.commit()
+    conn.close()
+
+    return is_updated
+
+
+def manage_with_csv(list_path, novel_id, latest_date):
+    """
+    CSV(.list)形式を用いて更新日時を管理し、更新の有無を返す関数
+    （これまでの処理をそのまま関数化したものです）
+    """
+    is_updated = True
+
+    if os.path.exists(list_path):
+        with open(list_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+            
+        new_lines = []
+        for line in lines:
+            if line.startswith(f"{novel_id},"):
+                parts = line.split(',', 2)
+                if len(parts) == 3:
+                    if latest_date and (latest_date in parts[2]):
+                        is_updated = False
+                        new_lines.append(line)
+                    else:
+                        sub_parts = parts[2].rsplit(',', 1)
+                        if len(sub_parts) == 2 and re.search(r'\d{4}/\d{2}/\d{2}', sub_parts[1]):
+                            new_line = f"{parts[0]},{parts[1]},{sub_parts[0]}, {latest_date}\n"
+                        else:
+                            clean_title = parts[2].rstrip('\n')
+                            new_line = f"{parts[0]},{parts[1]},{clean_title}, {latest_date}\n"
+                        new_lines.append(new_line)
+                else:
+                    new_lines.append(line)
+            else:
+                new_lines.append(line)
+                
+        if is_updated:
+            os.makedirs(os.path.dirname(list_path), exist_ok=True)
+            with open(list_path, "w", encoding="utf-8") as f:
+                f.writelines(new_lines)
+    else:
+        print(f"警告: リストファイルが見つかりません ({list_path})")
+
+    return is_updated
+
+# ==========================================
+
 class GetPagerContents():
     def __init__(self, soup):
         self.__soup = soup
+
 
 
 def main():
@@ -263,51 +373,17 @@ def main():
                 # 最新のエピソードの更新日を保持（一番最後が最新）
                 latest_date = ep_arry["Episode"][-1]["publishedAt"]
 
-    # 2. リストファイルを読み込み、更新チェック
-    list_dir = "../../novel_database/"
-    list_file = "narou_all_novel_id.list"
-    list_path = os.path.join(list_dir, list_file)
-    
-    is_updated = True # 初期値は更新あり
-
-    if os.path.exists(list_path):
-        with open(list_path, "r", encoding="utf-8") as f:
-            lines = f.readlines()
-            
-        new_lines = []
-        for line in lines:
-            if line.startswith(f"{novel_id},"):
-                # "id, flag, title[, date]" という構成を前提にパース
-                parts = line.split(',', 2)
-                if len(parts) == 3:
-                    # すでに同じ最新日時が記録されている場合は更新スキップ
-                    if latest_date and (latest_date in parts[2]):
-                        is_updated = False
-                        new_lines.append(line)
-                    else:
-                        # 既存の日付を正規表現で探して置換するか、追記する
-                        sub_parts = parts[2].rsplit(',', 1)
-                        if len(sub_parts) == 2 and re.search(r'\d{4}/\d{2}/\d{2}', sub_parts[1]):
-                            # 既に日付カラムがある場合は置換
-                            new_line = f"{parts[0]},{parts[1]},{sub_parts[0]}, {latest_date}\n"
-                        else:
-                            # 初回追記：末尾の改行を削って、日付カラムを追加
-                            clean_title = parts[2].rstrip('\n')
-                            new_line = f"{parts[0]},{parts[1]},{clean_title}, {latest_date}\n"
-                        new_lines.append(new_line)
-                else:
-                    new_lines.append(line)
-            else:
-                new_lines.append(line)
-                
-        # 更新が確認された場合のみ、リストファイルを上書き更新
-        if is_updated:
-            os.makedirs(list_dir, exist_ok=True)
-            with open(list_path, "w", encoding="utf-8") as f:
-                f.writelines(new_lines)
+    # 2. 設定されたモードに応じて、DBまたはCSVの更新関数を呼び出す
+    if MANAGEMENT_MODE == "sqlite":
+        print(f"[SQLiteモードで実行中] DB: {DB_FILE_NAME}")
+        is_updated = manage_with_sqlite(DB_FILE_PATH, novel_id, SITE_TYPE, novel_title, latest_date)
+    elif MANAGEMENT_MODE == "csv":
+        print(f"[CSVモードで実行中] List: {CSV_FILE_NAME}")
+        is_updated = manage_with_csv(CSV_FILE_PATH, novel_id, latest_date)
     else:
-        # リストファイルがない場合は警告を出しつつ、出力自体は行う
-        print(f"警告: リストファイルが見つかりません ({list_path})")
+        print("エラー: MANAGEMENT_MODE の設定が不正です。")
+        sys.exit(1)
+
 
     # 3. 更新有無に応じたHTML/JSONの出力
     if is_updated:


### PR DESCRIPTION
いろいろ改修
- 複数読み物サイトの一括取得スクリプトをshスクリプトからpyスクリプトに変更
- ノベルの取得用データベースをCSV形式からSQLiteでのDB形式に変更
- スクリプト本体でCSVでもDBからでもデータを読み込めるように修正
- novel_id単体　もしくはリストから新規登録した際にDB側に登録情報が自動登録できるように修正
- Novelの更新時のみ、リストデータが更新されるように修正

などなど。
その他細かい解析ルーチンの効率化